### PR TITLE
Add basic betting controls and action handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,9 @@
       <button id="newHandBtn" class="btn">New Hand</button>
       <button id="nextBtn" class="btn" disabled>Next Street</button>
       <button id="showBtn" class="btn" disabled>Showdown</button>
+      <button id="foldBtn" class="btn" disabled>Fold</button>
+      <button id="callBtn" class="btn" disabled>Call/Check</button>
+      <button id="betBtn" class="btn" disabled>Bet/Raise</button>
       <div class="note">This starter focuses on dealing + hand strength. Betting/AI hooks are stubbed in <code>script.js</code> so you can expand later.</div>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -31,6 +31,12 @@ const logEl = (msg) => {
 
 const setStatus = (msg) => document.getElementById("status").textContent = msg;
 const setPot = () => document.getElementById("pot").textContent = `Pot: ${state.pot}`;
+function setActionButtons(disabled){
+  ["foldBtn","callBtn","betBtn"].forEach(id=>{
+    const el = document.getElementById(id);
+    if(el) el.disabled = disabled;
+  });
+}
 
 function formatCard(c){ return `${c.rank}${c.suit}`; }
 
@@ -273,6 +279,7 @@ function resetHand(){
   setStatus("Preflop: cards are being dealt…");
   document.getElementById("nextBtn").disabled = false;
   document.getElementById("showBtn").disabled = true;
+  setActionButtons(false);
   render();
 }
 
@@ -334,6 +341,40 @@ function showdown(){
   names.forEach(n=>logEl(`— ${n}`));
   // Reveal CPU cards
   render();
+  setActionButtons(true);
+}
+
+function bettingRound(action){
+  const hero = state.players[0];
+  if(state.street === "idle"){
+    logEl("Dealer: No hand in progress.");
+    return;
+  }
+  switch(action){
+    case "fold":
+      hero.folded = true;
+      logEl(`${hero.name} folds.`);
+      setActionButtons(true);
+      break;
+    case "call":
+      logEl(`${hero.name} calls/checks.`);
+      break;
+    case "bet":
+      const amt = 50;
+      if(hero.stack >= amt){
+        hero.stack -= amt;
+        state.pot += amt;
+        logEl(`${hero.name} bets ${amt}.`);
+      } else if(hero.stack > 0){
+        state.pot += hero.stack;
+        logEl(`${hero.name} goes all-in for ${hero.stack}.`);
+        hero.stack = 0;
+      } else {
+        logEl(`${hero.name} has no chips left.`);
+      }
+      break;
+  }
+  render();
 }
 
 // ---------- Controls ----------
@@ -354,6 +395,9 @@ document.getElementById("newHandBtn").addEventListener("click", ()=>{
 });
 document.getElementById("nextBtn").addEventListener("click", nextStreet);
 document.getElementById("showBtn").addEventListener("click", showdown);
+document.getElementById("foldBtn").addEventListener("click", ()=>bettingRound("fold"));
+document.getElementById("callBtn").addEventListener("click", ()=>bettingRound("call"));
+document.getElementById("betBtn").addEventListener("click", ()=>bettingRound("bet"));
 
 // Initial render
 render();


### PR DESCRIPTION
## Summary
- add Fold, Call/Check and Bet/Raise buttons to control panel
- wire buttons to new bettingRound handler that logs actions and updates stacks and pot
- disable action buttons when appropriate during game flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6db22b5b083239d8331bba2679434