### PR TITLE
Add dealer rotation and blind posting

### DIFF
--- a/script.js
+++ b/script.js
@@ -261,6 +261,26 @@ function bestOf7(two, board){
 }
 
 // ---------- Game flow ----------
+function rotateDealer(){
+  const prev = document.querySelector('.seat.dealer');
+  if(prev) prev.classList.remove('dealer');
+  state.dealerPos = (state.dealerPos + 1) % state.players.length;
+  const seat = document.querySelector(`.seat[data-seat="${state.dealerPos}"]`);
+  if(seat) seat.classList.add('dealer');
+}
+
+function postBlinds(small, big){
+  const sbIdx = (state.dealerPos + 1) % state.players.length;
+  const bbIdx = (state.dealerPos + 2) % state.players.length;
+  const sb = Math.min(small, state.players[sbIdx].stack);
+  const bb = Math.min(big, state.players[bbIdx].stack);
+  state.players[sbIdx].stack -= sb;
+  state.players[bbIdx].stack -= bb;
+  state.pot = sb + bb;
+  logEl(`${state.players[sbIdx].name} posts small blind ${sb}.`);
+  logEl(`${state.players[bbIdx].name} posts big blind ${bb}.`);
+}
+
 function resetHand(){
   state.deck = buildDeck();
   state.board = [];
@@ -345,8 +365,9 @@ function nextStreet(){
 
 function newHand(){
   resetHand();
+  rotateDealer();
+  postBlinds(5, 10);
   dealHole();
-  // In a later version, rotate dealer & post blinds here
 }
 
 document.getElementById("newHandBtn").addEventListener("click", ()=>{

--- a/style.css
+++ b/style.css
@@ -37,9 +37,14 @@ body{background:#0d0f10;color:#e9ecef}
 }
 .seat{
   background:rgba(0,0,0,.25);border:1px solid rgba(255,255,255,.08);
-  border-radius:16px;padding:10px;box-shadow:inset 0 0 0 1px rgba(255,255,255,.03)
+  border-radius:16px;padding:10px;box-shadow:inset 0 0 0 1px rgba(255,255,255,.03);
+  position:relative
 }
 .seat.hero{outline:2px dashed var(--gold)}
+.seat.dealer::after{
+  content:"D";position:absolute;top:4px;right:4px;width:20px;height:20px;border-radius:50%;
+  background:var(--gold);color:#000;font-weight:700;display:flex;align-items:center;justify-content:center;font-size:.75rem
+}
 .seat-name{font-weight:700;margin-bottom:6px}
 .stack{margin-top:6px;color:var(--gold);font-weight:600}
 


### PR DESCRIPTION
## Summary
- Add dealer rotation helper to move the button
- Implement blind posting to seed the pot
- Start each hand by rotating dealer and posting blinds before dealing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6db2e8d88832383b4485d7ba90b14