### PR TITLE
Add betting round logic and tests

### DIFF
--- a/__tests__/bettingRound.test.js
+++ b/__tests__/bettingRound.test.js
@@ -1,0 +1,66 @@
+const { bettingRound } = require('../bettingRound');
+
+describe('bettingRound', () => {
+  test('processes raise, call, and fold correctly', () => {
+    const players = [
+      { stack: 100, bet: 0, folded: false },
+      { stack: 100, bet: 0, folded: false },
+      { stack: 100, bet: 0, folded: false }
+    ];
+
+    const actions = [
+      { playerIndex: 0, type: 'raise', amount: 10 },
+      { playerIndex: 1, type: 'call' },
+      { playerIndex: 2, type: 'fold' }
+    ];
+
+    const result = bettingRound(players, actions);
+
+    expect(result.pot).toBe(20);
+    expect(result.players[0].stack).toBe(90);
+    expect(result.players[1].stack).toBe(90);
+    expect(result.players[2].folded).toBe(true);
+    expect(result.sidePots).toEqual([{ amount: 20, players: [0, 1] }]);
+  });
+
+  test('handles equal all-ins', () => {
+    const players = [
+      { stack: 50, bet: 0, folded: false },
+      { stack: 50, bet: 0, folded: false }
+    ];
+
+    const actions = [
+      { playerIndex: 0, type: 'raise', amount: 50 },
+      { playerIndex: 1, type: 'call' }
+    ];
+
+    const result = bettingRound(players, actions);
+
+    expect(result.pot).toBe(100);
+    expect(result.players[0].stack).toBe(0);
+    expect(result.players[1].stack).toBe(0);
+    expect(result.sidePots).toEqual([{ amount: 100, players: [0, 1] }]);
+  });
+
+  test('creates side pot when all-in with different amounts', () => {
+    const players = [
+      { stack: 50, bet: 0, folded: false },
+      { stack: 100, bet: 0, folded: false },
+      { stack: 100, bet: 0, folded: false }
+    ];
+
+    const actions = [
+      { playerIndex: 0, type: 'raise', amount: 50 },
+      { playerIndex: 1, type: 'raise', amount: 50 },
+      { playerIndex: 2, type: 'call' }
+    ];
+
+    const result = bettingRound(players, actions);
+
+    expect(result.pot).toBe(250);
+    expect(result.sidePots).toEqual([
+      { amount: 150, players: [0, 1, 2] },
+      { amount: 100, players: [1, 2] }
+    ]);
+  });
+});

--- a/bettingRound.js
+++ b/bettingRound.js
@@ -1,0 +1,62 @@
+function bettingRound(players, actions) {
+  let currentBet = 0;
+
+  actions.forEach(action => {
+    const player = players[action.playerIndex];
+    if (!player || player.folded || player.allIn) return;
+
+    player.bet = player.bet || 0;
+
+    switch (action.type) {
+      case 'fold':
+        player.folded = true;
+        break;
+      case 'call': {
+        let toCall = currentBet - player.bet;
+        if (toCall > player.stack) {
+          toCall = player.stack;
+          player.allIn = true;
+        }
+        player.stack -= toCall;
+        player.bet += toCall;
+        if (player.stack === 0) player.allIn = true;
+        break;
+      }
+      case 'raise': {
+        let toCall = currentBet - player.bet;
+        let total = toCall + (action.amount || 0);
+        if (total >= player.stack) {
+          total = player.stack;
+          player.allIn = true;
+        }
+        player.stack -= total;
+        player.bet += total;
+        currentBet = Math.max(currentBet, player.bet);
+        if (player.stack === 0) player.allIn = true;
+        break;
+      }
+    }
+  });
+
+  const pot = players.reduce((sum, p) => sum + (p.bet || 0), 0);
+
+  const active = players
+    .map((p, idx) => ({ idx, bet: p.bet || 0, folded: p.folded }))
+    .filter(p => !p.folded && p.bet > 0)
+    .sort((a, b) => a.bet - b.bet);
+
+  const sidePots = [];
+  let prev = 0;
+  while (active.length > 0) {
+    const curr = active[0].bet;
+    const eligible = active.map(p => p.idx);
+    const amount = (curr - prev) * eligible.length;
+    if (amount > 0) sidePots.push({ amount, players: eligible });
+    prev = curr;
+    active.shift();
+  }
+
+  return { players, pot, sidePots };
+}
+
+module.exports = { bettingRound };

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "A whimsical Texas hold 'em poker game with a rat dealer.",
   "scripts": {
-    "test": "echo 'No tests yet'"
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `bettingRound` function to handle calls, raises, folds, and side pots
- configure Jest test runner
- write unit tests covering call/raise/fold, all-in, and side-pot scenarios

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6db6c13808323bec27f0d6f127f79