### PR TITLE
Implement bet reset utility for game flow

### DIFF
--- a/script.js
+++ b/script.js
@@ -267,6 +267,14 @@ function bestOf7(two, board){
 }
 
 // ---------- Game flow ----------
+function resetBets(){
+  state.players.forEach(p=>{
+    p.currentBet = 0;
+    // A player remains all-in only if they have no chips left
+    p.allIn = p.stack === 0;
+  });
+}
+
 function rotateDealer(){
   const prev = document.querySelector('.seat.dealer');
   if(prev) prev.classList.remove('dealer');


### PR DESCRIPTION
## Summary
- add resetBets function to clear per-hand bets and retain all-in when stack is zero

## Testing
- `npm test` (fails: command not found: npm)


------
https://chatgpt.com/codex/tasks/task_e_68c6e41e33308323925d5e8727725b6d