### PR TITLE
Mobile: Scaffold Capacitor native wrapper (issue #20)

### DIFF
--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -1,0 +1,6 @@
+{
+  "appId": "com.criss.riverrat",
+  "appName": "River Rat Poker",
+  "webDir": "dist",
+  "bundledWebRuntime": false
+}

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -2,5 +2,13 @@
   "appId": "com.criss.riverrat",
   "appName": "River Rat Poker",
   "webDir": "dist",
-  "bundledWebRuntime": false
+  "bundledWebRuntime": false,
+  "plugins": {
+    "SplashScreen": {
+      "launchShowDuration": 3000,
+      "androidScaleType": "CENTER_CROP",
+      "splashFullScreen": false,
+      "splashImmersive": false
+    }
+  }
 }

--- a/docs/CAPACITOR.md
+++ b/docs/CAPACITOR.md
@@ -1,0 +1,37 @@
+Capacitor integration notes
+
+This doc provides a minimal scaffold to wrap River Rat Poker with Capacitor.
+
+What was added
+- capacitor.config.json (webDir: dist)
+- package.json scripts for common Capacitor commands
+- docs/CAPACITOR.md (this file)
+- native/ folder placeholder with README
+
+Getting started (developer)
+1. Install the Capacitor CLI and core (locally):
+   npm install --save-dev @capacitor/cli @capacitor/core
+
+2. Build the web app:
+   npm run build
+
+3. Initialize Capacitor (only first-time):
+   npm run native:init
+   or: npx cap init "River Rat Poker" com.criss.riverrat --web-dir=dist
+
+4. Add platforms:
+   npm run native:add:android
+   npm run native:add:ios
+
+5. Sync after any web changes:
+   npm run native:sync
+
+6. Open native IDEs:
+   npm run native:open:android
+   npm run native:open:ios
+
+Notes
+- This scaffold does NOT include platform folders; running the add platform commands will create them.
+- iOS builds require macOS and Xcode. Android builds require Android Studio and SDK.
+- After adding platforms, avoid committing large native files unless intentionally tracking native project changes.
+- Consider running: npm ci after updating package.json to install Capacitor packages.

--- a/docs/CAPACITOR_RESOURCES.md
+++ b/docs/CAPACITOR_RESOURCES.md
@@ -1,0 +1,37 @@
+Generating Android / iOS icons and splash screens
+
+This document explains a minimal, repeatable approach for creating native app icons and splash screens for Capacitor (issue #20 follow-up).
+
+Prerequisites
+- Install cordova-res (or use npx to run it without installing):
+  npm install --save-dev cordova-res
+
+Source artwork
+- Prepare a square source PNG (recommended 1024x1024) for the app icon.
+- Prepare a splash source PNG (recommended 2732x2732 with safe area centered) for splash screens.
+- The repo already contains a dealer rat PNG: assets/dealer_rat/Rat_Happy.png. Use that as a starting point:
+
+  mkdir -p resources && cp assets/dealer_rat/Rat_Happy.png resources/icon.png && cp assets/dealer_rat/Rat_Happy.png resources/splash.png
+
+Generating resources with cordova-res
+- Run (will create native/icon and native/splash folders and platform resources in android/ and ios/ if present):
+  npx cordova-res --skip-config --copy
+
+- Or to target specific platforms:
+  npx cordova-res android --skip-config --copy
+  npx cordova-res ios --skip-config --copy
+
+Notes
+- cordova-res will place generated images in resources/android and resources/ios and copy them into platform projects when available.
+- Alternatively, use community tools such as @capacitor/assets or generate assets manually.
+- After generating resources, run `npx cap sync` to ensure native projects pick them up.
+
+Example npm script (already added):
+  "native:generate-resources": "npx cordova-res --skip-config --copy"
+
+Committing resources
+- Generated native platform folders (android/ios) are large; it's common to keep them out of git and add them to .gitignore. Commit the source `resources/icon.png`/`resources/splash.png` if you want to keep canonical artwork in the repo.
+
+Follow-up
+- Replace placeholder artwork with polished app icons and splash images (designer deliverables).
+- Consider using adaptive icons for Android (foreground/background layers) for best results.

--- a/native/README.md
+++ b/native/README.md
@@ -1,0 +1,9 @@
+Native wrapper placeholder
+
+This folder is a placeholder for native platform projects created by Capacitor.
+
+Workflow:
+- Run `npm run native:add:android` or `npm run native:add:ios` to create platform folders.
+- The created folders (android/ios) are typically large; decide whether to add them to source control.
+
+For now, the repository keeps native integrations out of the main tree until a decision is made.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "native:add:ios": "npx cap add ios",
     "native:sync": "npx cap sync",
     "native:open:android": "npx cap open android",
-    "native:open:ios": "npx cap open ios"
+    "native:open:ios": "npx cap open ios",
+    "native:generate-resources": "npx cordova-res --skip-config --copy || echo 'install cordova-res to generate native icons'"
   },
   "devDependencies": {
     "@capacitor/cli": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,17 @@
     "build": "node scripts/prepare-pages.mjs",
     "dev": "node scripts/dev-server.mjs",
     "start": "npm run dev",
-    "test": "node scripts/smoke-test.mjs"
+    "test": "node scripts/smoke-test.mjs",
+    "native:init": "npx @capacitor/cli init \"River Rat Poker\" com.criss.riverrat --web-dir=dist",
+    "native:build:web": "npm run build",
+    "native:add:android": "npx cap add android",
+    "native:add:ios": "npx cap add ios",
+    "native:sync": "npx cap sync",
+    "native:open:android": "npx cap open android",
+    "native:open:ios": "npx cap open ios"
+  },
+  "devDependencies": {
+    "@capacitor/cli": "^5.0.0",
+    "@capacitor/core": "^5.0.0"
   }
 }

--- a/resources/icon.svg
+++ b/resources/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024">\n  <rect width="100%" height="100%" fill="#16776f"/>\n  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Georgia, serif" font-size="220" fill="#fff">RR</text>\n</svg>

--- a/resources/splash.svg
+++ b/resources/splash.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2732" height="2732" viewBox="0 0 2732 2732">
+  <rect width="100%" height="100%" fill="#160b08"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Georgia, serif" font-size="400" fill="#f3c846">River Rat</text>
+</svg>


### PR DESCRIPTION
Scaffold Capacitor integration for River Rat Poker (issue #20)\n\nWhat changed:\n- Added capacitor.config.json (webDir: dist)\n- Added npm scripts for Capacitor commands to package.json\n- Added docs/CAPACITOR.md with developer instructions\n- Added native/ placeholder folder with .gitkeep and README\n\nNotes:\n- This PR only scaffolds configuration and docs. Run npm install to install @capacitor/cli and @capacitor/core, then follow docs to add platforms.\n\nRefs: #20\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>