### PR TITLE
[codex] Refine mobile landscape poker HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>River Rat Poker</title>
-    <link rel="stylesheet" href="style.css?v=20260626-mobile-landscape" />
+    <link rel="stylesheet" href="style.css?v=20260626-mobile-minimal" />
 
     <!-- PWA & mobile install -->
     <link rel="manifest" href="manifest.json" />

--- a/script.js
+++ b/script.js
@@ -778,6 +778,7 @@ function renderPlayers() {
       els.seats[index].dataset.state = state;
       els.seats[index].innerHTML = `
         <div class="opponent-meta">
+          <span class="opponent-name">${player.name}</span>
           <span class="opponent-stack">$${player.stack}</span>
           <span class="opponent-bet">$${player.committed}</span>
         </div>

--- a/style.css
+++ b/style.css
@@ -1799,78 +1799,99 @@ input[type="range"] {
     grid-template-areas:
       "top"
       "table";
-    gap: 6px;
+    gap: 4px;
     width: 100%;
     height: 100svh;
     padding:
-      max(5px, env(safe-area-inset-top))
-      max(8px, env(safe-area-inset-right))
-      max(6px, env(safe-area-inset-bottom))
-      max(8px, env(safe-area-inset-left));
+      max(3px, env(safe-area-inset-top))
+      max(7px, env(safe-area-inset-right))
+      max(5px, env(safe-area-inset-bottom))
+      max(7px, env(safe-area-inset-left));
     overflow: hidden;
   }
 
   .top-bar {
     grid-area: top;
-    min-height: 44px;
-    padding: 5px 8px;
-    border-radius: 10px;
+    min-height: 34px;
+    padding: 3px 7px;
     gap: 8px;
-    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.32);
+    border-color: rgba(148, 163, 184, 0.14);
+    border-radius: 8px;
+    background: rgba(7, 12, 22, 0.7);
+    box-shadow: none;
+    backdrop-filter: blur(12px);
   }
 
   .eyebrow {
-    margin-bottom: 1px;
-    font-size: 0.5rem;
+    display: none;
   }
 
   h1 {
-    font-size: clamp(1rem, 3.1vw, 1.35rem);
+    font-size: clamp(0.9rem, 2.35vw, 1.12rem);
+    text-shadow: none;
   }
 
   .top-actions {
-    gap: 6px;
+    gap: 5px;
   }
 
   .top-actions .icon-button {
-    width: 38px;
-    height: 38px;
-    min-width: 38px;
-    min-height: 38px;
-    border-radius: 10px;
+    width: 31px;
+    height: 31px;
+    min-width: 31px;
+    min-height: 31px;
+    border-radius: 8px;
+    font-size: 0.78rem;
   }
 
   .wood-button {
-    min-width: 88px;
-    min-height: 38px;
-    padding: 6px 10px;
-    border-radius: 10px;
-    font-size: 0.86rem;
+    min-width: 72px;
+    min-height: 31px;
+    padding: 4px 8px;
+    border-radius: 8px;
+    font-size: 0.73rem;
+    box-shadow: 0 8px 14px rgba(250, 204, 21, 0.16);
   }
 
   .table-stage {
     grid-area: table;
-    --table-side-inset: clamp(74px, 14vw, 118px);
-    --table-block-inset: clamp(56px, 13svh, 70px);
-    --seat-edge-inset: 6px;
-    --dealer-size: clamp(54px, 10svh, 72px);
-    height: calc(100svh - 58px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+    --dealer-size: clamp(50px, 11.4svh, 64px);
+    --table-side-inset: clamp(112px, 18.5vw, 156px);
+    --table-block-inset: clamp(42px, 10.5svh, 54px);
+    --seat-edge-inset: 7px;
+    height: calc(100svh - 43px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
     min-height: 0;
     max-height: none;
     margin: 0;
-    border-radius: 14px;
     overflow: hidden;
+    border-color: transparent;
+    border-radius: 10px;
+    background:
+      radial-gradient(ellipse at 50% 54%, rgba(20, 184, 166, 0.16), transparent 50%),
+      rgba(3, 7, 18, 0.72);
+    box-shadow: none;
   }
 
   .poker-table {
     top: var(--table-block-inset);
-    bottom: clamp(64px, 15svh, 80px);
-    width: calc(100% - (var(--table-side-inset) * 2));
+    bottom: clamp(50px, 13.2svh, 66px);
+    left: 50%;
+    width: min(620px, calc(100% - (var(--table-side-inset) * 2)));
     min-width: 0;
-    border-radius: 18px;
+    border-color: rgba(20, 184, 166, 0.18);
+    border-radius: 22px;
+    background:
+      linear-gradient(rgba(8, 47, 73, 0.22), rgba(8, 47, 73, 0.28)),
+      url("assets/table/Table.png") center / 100% 100% no-repeat;
     box-shadow:
-      inset 0 0 36px rgba(20, 184, 166, 0.24),
-      0 14px 34px rgba(0, 0, 0, 0.44);
+      inset 0 0 30px rgba(20, 184, 166, 0.18),
+      0 12px 28px rgba(0, 0, 0, 0.34);
+    transform: translateX(-50%);
+  }
+
+  .felt-ripples,
+  .poker-table::after {
+    opacity: 0.18;
   }
 
   .poker-table::after {
@@ -1878,63 +1899,70 @@ input[type="range"] {
   }
 
   .table-center {
-    gap: 4px;
-    padding: 18px 8px 8px;
+    gap: 3px;
+    padding: 15px 8px 7px;
   }
 
   .pot-display {
-    min-width: 118px;
-    gap: 6px;
-    padding: 5px 9px;
+    min-width: auto;
+    gap: 4px;
+    padding: 3px 8px;
     border-width: 1px;
+    border-color: rgba(216, 255, 247, 0.2);
+    background: rgba(8, 13, 23, 0.62);
+    box-shadow: none;
   }
 
   .pot-icon {
-    width: 32px;
-    height: 32px;
+    width: 24px;
+    height: 24px;
   }
 
   #pot-amount {
-    font-size: 0.92rem;
+    font-size: 0.78rem;
   }
 
   #street-label {
-    font-size: 0.58rem;
+    font-size: 0.5rem;
   }
 
   .community-cards {
-    min-height: 46px;
-    gap: 3px;
+    min-height: 42px;
+    gap: clamp(3px, 0.8vw, 6px);
   }
 
   .community-cards .card,
   .card {
-    width: clamp(31px, 5.6vw, 44px);
-    height: clamp(44px, 7.9vw, 62px);
+    width: clamp(30px, 5.2vw, 42px);
+    height: clamp(42px, 7.3vw, 58px);
     border-radius: 4px;
   }
 
   .turn-info {
     min-height: 16px;
-    width: min(92%, 260px);
-    font-size: 0.66rem;
+    width: min(90%, 230px);
+    color: rgba(217, 255, 247, 0.82);
+    font-size: 0.58rem;
+    font-weight: 750;
     line-height: 1.15;
     text-shadow: 0 1px 4px var(--ink);
   }
 
   .chip-bank {
-    min-height: 20px;
+    min-height: 17px;
     margin-top: -5px;
+    opacity: 0.9;
   }
 
   .chip-bank img {
-    width: 20px;
-    height: 20px;
-    margin-left: -7px;
+    width: 17px;
+    height: 17px;
+    margin-left: -6px;
   }
 
   .dealer-character {
-    top: clamp(38px, 8.5svh, 52px);
+    top: clamp(30px, 7.8svh, 42px);
+    z-index: 3;
     width: calc(var(--dealer-size) + 12px);
     gap: 0;
   }
@@ -1942,13 +1970,16 @@ input[type="range"] {
   .dealer-character img {
     width: var(--dealer-size);
     height: var(--dealer-size);
+    filter: drop-shadow(0 6px 5px rgba(0, 0, 0, 0.38));
   }
 
   .dealer-character span {
-    padding: 1px 6px;
-    border-width: 1px;
-    font-size: 0.5rem;
-    white-space: nowrap;
+    display: none;
+  }
+
+  .player-panel,
+  .opponent-pod {
+    backdrop-filter: blur(8px);
   }
 
   .player-panel {
@@ -1960,162 +1991,239 @@ input[type="range"] {
   }
 
   .opponent-pod {
-    width: 112px;
-    min-height: 48px;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 28px;
+    width: clamp(88px, 13vw, 112px);
+    min-height: 40px;
+    padding: 4px 5px;
     gap: 4px;
-    padding: 4px 6px;
-    border-radius: 999px;
+    border-color: rgba(148, 163, 184, 0.22);
+    border-radius: 8px;
+    background: rgba(8, 13, 23, 0.58);
+    box-shadow: 0 8px 15px rgba(0, 0, 0, 0.24);
   }
 
-  .top-left-seat {
-    top: 4px;
-    left: clamp(118px, 25vw, 212px);
-    transform: translateX(-50%);
+  .opponent-pod[data-style="passive"],
+  .opponent-pod[data-style="balanced"],
+  .opponent-pod[data-style="aggressive"] {
+    background: rgba(8, 13, 23, 0.58);
   }
 
-  .top-right-seat {
-    top: 4px;
-    right: clamp(118px, 25vw, 212px);
-    transform: translateX(50%);
+  .opponent-pod.is-turn,
+  .opponent-pod[data-state="active"] {
+    border-color: rgba(250, 204, 21, 0.66);
+    box-shadow:
+      0 0 0 2px rgba(250, 204, 21, 0.16),
+      0 8px 16px rgba(0, 0, 0, 0.3);
+    animation: none;
   }
 
-  .left-seat {
-    top: 50%;
-    left: var(--seat-edge-inset);
-    transform: translateY(-45%);
-  }
-
-  .right-seat {
-    top: 50%;
-    right: var(--seat-edge-inset);
-    transform: translateY(-45%);
-  }
-
-  .human-seat {
-    left: max(8px, env(safe-area-inset-left));
-    bottom: max(5px, env(safe-area-inset-bottom));
-    width: clamp(214px, 36vw, 280px);
-    min-height: 68px;
-    transform: none;
-  }
-
-  .player-head {
-    gap: 4px;
-    margin-bottom: 3px;
-  }
-
-  .player-name {
-    font-size: 0.62rem;
-    line-height: 1.05;
-  }
-
-  .badge-row {
-    gap: 2px;
-  }
-
-  .badge {
-    min-width: 17px;
-    height: 17px;
-    padding: 0 4px;
-    font-size: 0.48rem;
-  }
-
-  .player-stats {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 3px;
-    margin-bottom: 3px;
-    font-size: 0.46rem;
-  }
-
-  .player-stats strong {
-    font-size: 0.58rem;
-    overflow-wrap: anywhere;
-  }
-
-  .player-panel .card {
-    width: 24px;
-    height: 34px;
-    border-radius: 4px;
-  }
-
-  .human-seat .card {
-    width: 30px;
-    height: 42px;
+  .opponent-pod[data-state="waiting"] {
+    opacity: 0.86;
+    animation: none;
   }
 
   .opponent-meta {
-    gap: 2px;
+    gap: 1px;
+    align-content: center;
+    text-shadow: none;
+  }
+
+  .opponent-name {
+    display: block;
+    max-width: 100%;
+    overflow: hidden;
+    color: rgba(217, 255, 247, 0.78);
+    font-size: 0.48rem;
+    font-weight: 850;
+    line-height: 1;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    white-space: nowrap;
   }
 
   .opponent-stack,
   .opponent-bet {
-    min-height: 17px;
-    padding: 2px 6px;
+    min-height: 14px;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    line-height: 1;
   }
 
   .opponent-stack {
+    color: var(--paper);
     font-size: 0.62rem;
   }
 
   .opponent-bet {
-    font-size: 0.54rem;
+    color: rgba(250, 204, 21, 0.86);
+    font-size: 0.52rem;
+  }
+
+  .opponent-bet::before {
+    content: "Bet ";
+    color: rgba(217, 255, 247, 0.48);
+    font-weight: 800;
   }
 
   .opponent-cards {
-    width: 32px;
-    min-width: 32px;
+    width: 28px;
+    min-width: 28px;
     height: 30px;
   }
 
   .opponent-cards .card {
-    width: 18px;
-    height: 26px;
+    width: 16px;
+    height: 23px;
   }
 
   .opponent-cards .card + .card {
-    margin-left: -10px;
+    margin-left: -9px;
   }
 
   .opponent-badges {
-    top: -6px;
+    top: -7px;
     right: -5px;
     gap: 2px;
   }
 
   .status-glyph {
-    min-width: 16px;
-    height: 16px;
+    min-width: 15px;
+    height: 15px;
+    padding: 0 3px;
+    border: 0;
+    font-size: 0.45rem;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.26);
+  }
+
+  .top-left-seat {
+    top: 7px;
+    left: 33%;
+    transform: translateX(-50%);
+  }
+
+  .top-right-seat {
+    top: 7px;
+    right: 33%;
+    transform: translateX(50%);
+  }
+
+  .left-seat {
+    top: 52%;
+    left: max(7px, env(safe-area-inset-left));
+    transform: translateY(-45%);
+  }
+
+  .right-seat {
+    top: 52%;
+    right: calc(clamp(190px, 28vw, 246px) + max(8px, env(safe-area-inset-right)));
+    transform: translateY(-45%);
+  }
+
+  .human-seat {
+    left: max(8px, env(safe-area-inset-left));
+    bottom: max(8px, env(safe-area-inset-bottom));
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    width: clamp(180px, 29vw, 230px);
+    min-height: 54px;
+    padding: 5px 7px;
+    border-color: rgba(250, 204, 21, 0.3);
+    border-radius: 10px;
+    background:
+      linear-gradient(180deg, rgba(15, 23, 42, 0.66), rgba(8, 13, 23, 0.7)),
+      var(--seat-art, url("assets/table/Seat_1.png")) center / cover no-repeat;
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.3);
+    transform: none;
+  }
+
+  .human-seat .player-head {
+    grid-column: 1;
+    margin: 0 0 3px;
+  }
+
+  .human-seat .player-name {
+    font-size: 0.62rem;
+  }
+
+  .human-seat .player-stats {
+    grid-column: 1;
+    grid-template-columns: repeat(2, max-content);
+    gap: 3px 8px;
+    margin: 0;
+    font-size: 0.46rem;
+  }
+
+  .human-seat .player-stats div:last-child {
+    display: none;
+  }
+
+  .human-seat .player-stats span {
+    display: none;
+  }
+
+  .human-seat .player-stats strong {
+    overflow-wrap: anywhere;
+    font-size: 0.62rem;
+  }
+
+  .human-seat .card-row {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+    gap: 3px;
+  }
+
+  .human-seat .card {
+    width: clamp(26px, 4.7vw, 34px);
+    height: clamp(37px, 6.6vw, 48px);
+  }
+
+  .badge-row {
+    flex-wrap: nowrap;
+    gap: 2px;
+  }
+
+  .badge {
+    min-width: 15px;
+    height: 15px;
     padding: 0 4px;
-    font-size: 0.48rem;
+    border: 0;
+    font-size: 0.45rem;
   }
 
   .action-bar {
     position: fixed;
     z-index: 80;
-    right: max(8px, env(safe-area-inset-right));
-    bottom: max(6px, env(safe-area-inset-bottom));
-    left: auto;
     top: auto;
+    right: max(7px, env(safe-area-inset-right));
+    bottom: max(8px, env(safe-area-inset-bottom));
+    left: auto;
     display: grid;
     grid-template-columns: minmax(0, 1fr);
-    width: min(342px, calc(58vw - env(safe-area-inset-left) - env(safe-area-inset-right)));
-    min-width: 284px;
-    max-height: calc(100svh - 62px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
-    gap: 5px;
+    width: clamp(176px, 25vw, 232px);
+    min-width: 0;
+    max-height: calc(100svh - 46px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+    gap: 4px;
     align-self: auto;
-    padding: 7px;
-    border-radius: 12px;
+    padding: 6px;
     overflow: hidden;
-    box-shadow: 0 14px 34px rgba(0, 0, 0, 0.46);
+    border-color: rgba(148, 163, 184, 0.18);
+    border-radius: 10px;
+    background: rgba(7, 12, 22, 0.74);
+    box-shadow: 0 12px 26px rgba(0, 0, 0, 0.38);
+    backdrop-filter: blur(12px);
   }
 
   .action-summary {
-    min-height: 28px;
+    min-height: 24px;
     gap: 6px;
   }
 
   .action-summary strong {
-    font-size: 0.78rem;
+    font-size: 0.68rem;
     line-height: 1;
   }
 
@@ -2124,16 +2232,17 @@ input[type="range"] {
   }
 
   .action-summary .icon-button {
-    width: 34px;
-    height: 34px;
-    min-width: 34px;
-    min-height: 34px;
-    border-radius: 9px;
-    font-size: 0.9rem;
+    width: 28px;
+    height: 28px;
+    min-width: 28px;
+    min-height: 28px;
+    border-radius: 7px;
+    font-size: 0.76rem;
   }
 
   .amount-control {
-    gap: 4px;
+    gap: 2px;
+    padding: 2px 0;
   }
 
   .amount-head {
@@ -2141,42 +2250,43 @@ input[type="range"] {
   }
 
   .amount-control label {
-    font-size: 0.58rem;
+    font-size: 0.48rem;
   }
 
   #bet-value {
-    font-size: 0.96rem;
+    font-size: 0.78rem;
   }
 
   .amount-stepper {
-    grid-template-columns: 36px minmax(0, 1fr) 36px;
-    gap: 6px;
+    grid-template-columns: 28px minmax(0, 1fr) 28px;
+    gap: 4px;
   }
 
   .amount-stepper button {
-    width: 36px;
-    min-width: 36px;
-    min-height: 36px;
-    border-radius: 8px;
-    font-size: 1rem;
+    width: 28px;
+    min-width: 28px;
+    min-height: 28px;
+    border-radius: 7px;
+    font-size: 0.82rem;
   }
 
   input[type="range"] {
-    min-height: 36px;
+    min-height: 28px;
   }
 
   .actions {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 6px;
+    grid-template-columns: 1fr;
+    gap: 5px;
   }
 
   .actions button {
     min-width: 0;
-    min-height: 44px;
+    min-height: 36px;
     padding: 5px 6px;
-    border-radius: 9px;
-    font-size: 0.82rem;
+    border-radius: 8px;
+    font-size: 0.72rem;
+    box-shadow: 0 8px 14px rgba(0, 0, 0, 0.22);
   }
 
   .below-table {
@@ -2195,9 +2305,9 @@ input[type="range"] {
     position: fixed;
     z-index: 90;
     left: max(8px, env(safe-area-inset-left));
-    right: max(8px, env(safe-area-inset-right));
-    bottom: calc(116px + env(safe-area-inset-bottom));
-    max-height: min(42svh, 190px);
+    right: calc(clamp(176px, 25vw, 232px) + max(18px, env(safe-area-inset-right)));
+    bottom: max(8px, env(safe-area-inset-bottom));
+    max-height: min(54svh, 210px);
     margin: 0;
     padding: 8px 10px;
     overflow: auto;
@@ -2207,25 +2317,33 @@ input[type="range"] {
 
 @media (max-width: 760px) and (orientation: landscape) {
   .table-stage {
-    --table-side-inset: clamp(58px, 12vw, 86px);
-    --table-block-inset: clamp(50px, 12svh, 60px);
+    --table-side-inset: clamp(92px, 17vw, 124px);
+    --table-block-inset: clamp(40px, 10svh, 50px);
   }
 
   .top-left-seat {
-    left: clamp(96px, 23vw, 156px);
+    left: 31%;
   }
 
   .top-right-seat {
-    right: clamp(96px, 23vw, 156px);
+    right: 31%;
+  }
+
+  .right-seat {
+    right: calc(clamp(172px, 30vw, 210px) + max(8px, env(safe-area-inset-right)));
   }
 
   .human-seat {
-    width: clamp(194px, 34vw, 234px);
+    width: clamp(172px, 30vw, 214px);
   }
 
   .action-bar {
-    width: min(310px, calc(56vw - env(safe-area-inset-left) - env(safe-area-inset-right)));
-    min-width: 260px;
+    width: clamp(168px, 28vw, 208px);
+  }
+
+  .settings-panel[open],
+  .log-panel[open] {
+    right: calc(clamp(168px, 28vw, 208px) + max(18px, env(safe-area-inset-right)));
   }
 }
 


### PR DESCRIPTION
## What changed

- Refined the mobile landscape HUD to make the table the central visual anchor.
- Reduced the mobile header height and simplified its chrome.
- Converted opponent pods into smaller name/stack/bet badges with tucked cards.
- Tightened the human player panel to essential stack, bet, badges, and cards.
- Slimmed the right-side action area into a compact stacked control rail.
- Kept existing River Rat Poker table, dealer, chip, and card assets unchanged.

## Validation

- `npm run build`
- `npm test`
- `npm run native:sync`
- Local dev server fetches for `/`, the cache-busted stylesheet, script, dealer art, and table art.
