### PR TITLE
Polish mobile landscape poker UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>River Rat Poker</title>
     <link rel="stylesheet" href="style.css?v=20260626-mobile-minimal" />
+    <link rel="stylesheet" href="premium-ui.css?v=20260626-premium-mobile" />
 
     <!-- PWA & mobile install -->
     <link rel="manifest" href="manifest.json" />

--- a/premium-ui.css
+++ b/premium-ui.css
@@ -1,0 +1,580 @@
+/* Premium mobile casino UI pass. CSS-only visual layer; gameplay and asset paths remain unchanged. */
+:root {
+  --bg-navy: #030712;
+  --bg-bayou: #061719;
+  --panel-glass: rgba(5, 12, 20, 0.72);
+  --panel-glass-strong: rgba(5, 13, 22, 0.88);
+  --teal-accent: #28d5c8;
+  --teal-deep: #0a746d;
+  --gold-accent: #ffd45a;
+  --gold-deep: #b98218;
+  --copper: #b56c35;
+  --danger-fold: #d24154;
+  --call-teal: #20b9bd;
+  --raise-gold: #ffd45a;
+  --muted-text: rgba(220, 255, 248, 0.68);
+  --hud-border: rgba(255, 212, 90, 0.28);
+  --hud-line: rgba(40, 213, 200, 0.24);
+  --hud-shadow: 0 18px 44px rgba(0, 0, 0, 0.42);
+}
+
+html {
+  background: var(--bg-navy);
+}
+
+body {
+  background:
+    radial-gradient(ellipse at 50% 42%, rgba(31, 213, 200, 0.25), transparent 30rem),
+    radial-gradient(circle at 14% 22%, rgba(255, 212, 90, 0.12), transparent 16rem),
+    radial-gradient(circle at 86% 18%, rgba(181, 108, 53, 0.12), transparent 19rem),
+    radial-gradient(ellipse at 50% 118%, rgba(8, 70, 68, 0.58), transparent 36rem),
+    linear-gradient(180deg, #09131e 0%, #061416 44%, #02050b 100%);
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse at 50% 46%, transparent 0 38%, rgba(0, 0, 0, 0.2) 62%, rgba(0, 0, 0, 0.72) 100%),
+    linear-gradient(90deg, rgba(0, 0, 0, 0.4), transparent 18%, transparent 82%, rgba(0, 0, 0, 0.44));
+}
+
+.top-bar,
+.action-bar,
+.settings-panel,
+.log-panel {
+  border-color: rgba(255, 212, 90, 0.2);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02)),
+    linear-gradient(135deg, rgba(40, 213, 200, 0.1), transparent 42%),
+    var(--panel-glass);
+  box-shadow: var(--hud-shadow), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.top-bar {
+  position: relative;
+  isolation: isolate;
+  min-height: 52px;
+  padding: 8px 12px;
+  border-radius: 999px;
+}
+
+.top-bar::before {
+  content: "";
+  position: absolute;
+  inset: 4px;
+  z-index: -1;
+  border-radius: inherit;
+  border: 1px solid rgba(40, 213, 200, 0.14);
+  background: linear-gradient(90deg, rgba(255, 212, 90, 0.12), transparent 34%, rgba(40, 213, 200, 0.12));
+}
+
+.eyebrow {
+  color: var(--muted-text);
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+}
+
+h1 {
+  color: #fff8dc;
+  font-weight: 950;
+  letter-spacing: 0.01em;
+  text-shadow: 0 2px 0 rgba(65, 36, 12, 0.78), 0 0 18px rgba(255, 212, 90, 0.22);
+}
+
+.wood-button,
+.icon-button {
+  border-color: rgba(255, 212, 90, 0.34);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0.03)),
+    linear-gradient(180deg, rgba(32, 50, 59, 0.92), rgba(7, 17, 25, 0.94));
+  box-shadow: 0 9px 18px rgba(0, 0, 0, 0.34), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.wood-button {
+  color: #201203;
+  border-color: rgba(255, 236, 150, 0.66);
+  background: linear-gradient(180deg, #ffeaa0 0%, #ffd45a 45%, #c78920 100%);
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.42);
+}
+
+.table-stage {
+  isolation: isolate;
+  border-color: rgba(255, 212, 90, 0.14);
+  background:
+    radial-gradient(ellipse at 50% 54%, rgba(40, 213, 200, 0.27), transparent 42%),
+    radial-gradient(circle at 50% 28%, rgba(255, 212, 90, 0.1), transparent 26%),
+    linear-gradient(180deg, rgba(8, 25, 31, 0.92), rgba(3, 7, 18, 0.94));
+  box-shadow:
+    inset 0 0 90px rgba(0, 0, 0, 0.52),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 22px 70px rgba(0, 0, 0, 0.46);
+}
+
+.table-stage::before,
+.table-stage::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.table-stage::before {
+  background:
+    radial-gradient(ellipse at 50% 47%, rgba(40, 213, 200, 0.22), transparent 34%),
+    radial-gradient(ellipse at 50% 58%, rgba(255, 212, 90, 0.08), transparent 42%);
+  filter: blur(10px);
+}
+
+.table-stage::after {
+  background:
+    linear-gradient(90deg, rgba(0, 0, 0, 0.52), transparent 19%, transparent 78%, rgba(0, 0, 0, 0.62)),
+    radial-gradient(ellipse at 50% 50%, transparent 38%, rgba(0, 0, 0, 0.46) 100%);
+}
+
+.poker-table,
+.dealer-character,
+.player-panel,
+.opponent-pod,
+.banner {
+  z-index: 2;
+}
+
+.poker-table {
+  border-color: rgba(255, 212, 90, 0.24);
+  box-shadow:
+    0 0 0 1px rgba(40, 213, 200, 0.16),
+    inset 0 0 54px rgba(40, 213, 200, 0.2),
+    inset 0 -16px 34px rgba(0, 0, 0, 0.28),
+    0 26px 64px rgba(0, 0, 0, 0.56),
+    0 0 42px rgba(40, 213, 200, 0.14);
+}
+
+.pot-display {
+  border-color: rgba(255, 212, 90, 0.32);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.02)),
+    rgba(3, 10, 16, 0.78);
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.34), 0 0 22px rgba(40, 213, 200, 0.12);
+}
+
+#pot-amount {
+  color: #fff4bf;
+}
+
+#street-label {
+  color: var(--muted-text);
+  letter-spacing: 0.06em;
+}
+
+.turn-info {
+  color: #e8fffb;
+  font-weight: 850;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.74);
+}
+
+.player-panel,
+.opponent-pod {
+  border-color: var(--hud-border);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.025)),
+    linear-gradient(135deg, rgba(40, 213, 200, 0.12), rgba(255, 212, 90, 0.055)),
+    var(--panel-glass-strong);
+  box-shadow:
+    0 12px 28px rgba(0, 0, 0, 0.36),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+.player-panel::before,
+.opponent-pod::before,
+.human-seat::before {
+  content: "";
+  position: absolute;
+  inset: 4px;
+  border: 1px solid rgba(40, 213, 200, 0.16);
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+.player-panel.is-turn,
+.opponent-pod.is-turn,
+.opponent-pod[data-state="active"] {
+  border-color: rgba(255, 212, 90, 0.74);
+  outline: 0;
+  box-shadow:
+    0 0 0 3px rgba(255, 212, 90, 0.12),
+    0 0 26px rgba(255, 212, 90, 0.28),
+    0 14px 30px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.opponent-pod {
+  position: absolute;
+  border-radius: 999px;
+}
+
+.opponent-name,
+.player-name {
+  color: #fff6d7;
+  font-weight: 950;
+  letter-spacing: 0.01em;
+}
+
+.opponent-stack,
+.opponent-bet,
+.player-stats strong {
+  font-variant-numeric: tabular-nums;
+}
+
+.opponent-stack {
+  background: rgba(0, 0, 0, 0.28);
+}
+
+.opponent-bet {
+  border-color: rgba(255, 212, 90, 0.26);
+  color: #ffe493;
+  background: rgba(255, 212, 90, 0.09);
+}
+
+.badge,
+.status-glyph {
+  border-color: rgba(255, 255, 255, 0.16);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.28);
+}
+
+.badge.dealer,
+.dealer-glyph {
+  background: linear-gradient(180deg, #fff0a8, #ffd45a 55%, #c98b22);
+}
+
+.badge.status,
+.blind-glyph {
+  background: linear-gradient(180deg, rgba(63, 220, 210, 0.94), rgba(17, 139, 134, 0.92));
+}
+
+.human-seat {
+  border-color: rgba(255, 212, 90, 0.4);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.03)),
+    linear-gradient(90deg, rgba(181, 108, 53, 0.18), transparent 42%, rgba(40, 213, 200, 0.1)),
+    var(--panel-glass-strong);
+}
+
+.human-seat .card {
+  filter: drop-shadow(0 9px 9px rgba(0, 0, 0, 0.42));
+}
+
+.action-bar {
+  border-color: rgba(255, 212, 90, 0.26);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.02)),
+    linear-gradient(135deg, rgba(181, 108, 53, 0.12), rgba(40, 213, 200, 0.08)),
+    rgba(4, 12, 20, 0.82);
+}
+
+.action-summary strong {
+  color: #fff6d7;
+  font-size: 0.94rem;
+  font-weight: 950;
+}
+
+.action-summary span {
+  color: var(--muted-text);
+}
+
+.amount-control {
+  padding: 8px;
+  border: 1px solid rgba(40, 213, 200, 0.16);
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.18);
+}
+
+.amount-control label {
+  color: var(--muted-text);
+  letter-spacing: 0.08em;
+}
+
+#bet-value {
+  color: #ffe493;
+  font-weight: 950;
+  text-shadow: 0 0 12px rgba(255, 212, 90, 0.18);
+}
+
+.amount-stepper button,
+.blind-control button {
+  border-radius: 10px;
+  border-color: rgba(40, 213, 200, 0.2);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.03)),
+    rgba(7, 20, 29, 0.86);
+}
+
+input[type="range"] {
+  accent-color: var(--raise-gold);
+}
+
+input[type="range"]::-webkit-slider-runnable-track {
+  height: 8px;
+  border-radius: 999px;
+  background:
+    linear-gradient(90deg, rgba(40, 213, 200, 0.88), rgba(255, 212, 90, 0.92)),
+    rgba(0, 0, 0, 0.28);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.42);
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  width: 24px;
+  height: 24px;
+  margin-top: -8px;
+  border: 2px solid #fff0a8;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #ffeaa0, #c98b22);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.38);
+  appearance: none;
+}
+
+.actions button {
+  position: relative;
+  overflow: hidden;
+  border-width: 1px;
+  border-radius: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.32);
+  box-shadow:
+    0 12px 22px rgba(0, 0, 0, 0.34),
+    inset 0 1px 0 rgba(255, 255, 255, 0.22),
+    inset 0 -3px 0 rgba(0, 0, 0, 0.2);
+}
+
+.actions button::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.2), transparent 38%);
+  pointer-events: none;
+}
+
+#fold-btn {
+  border-color: rgba(255, 176, 176, 0.36);
+  background: linear-gradient(180deg, #f36c78 0%, var(--danger-fold) 46%, #7f1425 100%);
+}
+
+#check-call-btn,
+#check-call-btn.call-mode {
+  border-color: rgba(142, 255, 246, 0.38);
+  background: linear-gradient(180deg, #63efe4 0%, var(--call-teal) 48%, #0a6265 100%);
+}
+
+#bet-raise-btn {
+  border-color: rgba(255, 245, 184, 0.68);
+  color: #241404;
+  background: linear-gradient(180deg, #fff4b8 0%, var(--raise-gold) 44%, #b87919 100%);
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.42);
+  box-shadow:
+    0 14px 26px rgba(255, 174, 41, 0.22),
+    0 12px 22px rgba(0, 0, 0, 0.34),
+    inset 0 1px 0 rgba(255, 255, 255, 0.34),
+    inset 0 -3px 0 rgba(75, 43, 4, 0.28);
+}
+
+@media (max-width: 950px) and (orientation: landscape) {
+  body {
+    background:
+      radial-gradient(ellipse at 46% 47%, rgba(40, 213, 200, 0.3), transparent 42%),
+      radial-gradient(circle at 18% 16%, rgba(255, 212, 90, 0.12), transparent 32%),
+      linear-gradient(180deg, #081621 0%, #061416 48%, #02050b 100%);
+  }
+
+  .game-shell {
+    gap: 6px;
+  }
+
+  .top-bar {
+    min-height: 35px;
+    padding: 4px 8px 4px 10px;
+    border-radius: 999px;
+    background:
+      linear-gradient(90deg, rgba(255, 212, 90, 0.12), rgba(40, 213, 200, 0.08)),
+      rgba(4, 12, 20, 0.7);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.24);
+  }
+
+  h1 {
+    font-size: clamp(0.92rem, 2.25vw, 1.12rem);
+    text-shadow: 0 1px 0 rgba(65, 36, 12, 0.78), 0 0 12px rgba(255, 212, 90, 0.16);
+  }
+
+  .wood-button {
+    min-width: 78px;
+    border-radius: 999px;
+    font-weight: 950;
+  }
+
+  .top-actions .icon-button,
+  .action-summary .icon-button {
+    border-radius: 999px;
+  }
+
+  .table-stage {
+    --table-side-inset: clamp(106px, 17.5vw, 152px);
+    border-radius: 18px;
+    background:
+      radial-gradient(ellipse at 50% 52%, rgba(40, 213, 200, 0.27), transparent 39%),
+      radial-gradient(ellipse at 46% 35%, rgba(255, 212, 90, 0.1), transparent 28%),
+      linear-gradient(180deg, rgba(7, 20, 29, 0.76), rgba(2, 7, 13, 0.9));
+  }
+
+  .poker-table {
+    border-color: rgba(255, 212, 90, 0.22);
+    box-shadow:
+      0 0 0 1px rgba(40, 213, 200, 0.12),
+      inset 0 0 34px rgba(40, 213, 200, 0.16),
+      0 14px 34px rgba(0, 0, 0, 0.42),
+      0 0 38px rgba(40, 213, 200, 0.12);
+  }
+
+  .pot-display {
+    padding: 4px 9px;
+    border-color: rgba(255, 212, 90, 0.28);
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.26);
+  }
+
+  #pot-amount {
+    font-size: 0.82rem;
+  }
+
+  .opponent-pod {
+    grid-template-columns: minmax(0, 1fr) 27px;
+    min-height: 43px;
+    border-radius: 999px;
+    border-color: rgba(255, 212, 90, 0.22);
+    background:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02)),
+      rgba(4, 12, 20, 0.68);
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  }
+
+  .opponent-name {
+    color: #fff0c4;
+    font-size: 0.5rem;
+  }
+
+  .opponent-stack {
+    font-size: 0.64rem;
+  }
+
+  .opponent-bet {
+    color: #ffdf82;
+  }
+
+  .human-seat {
+    min-height: 58px;
+    border-radius: 16px 16px 20px 20px;
+    border-color: rgba(255, 212, 90, 0.42);
+    background:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.02)),
+      linear-gradient(90deg, rgba(181, 108, 53, 0.2), rgba(40, 213, 200, 0.08)),
+      rgba(4, 12, 20, 0.78);
+    box-shadow:
+      0 10px 24px rgba(0, 0, 0, 0.34),
+      0 0 24px rgba(255, 212, 90, 0.08),
+      inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  }
+
+  .human-seat .player-name {
+    font-size: 0.66rem;
+  }
+
+  .human-seat .player-stats strong {
+    color: #f7fffd;
+    font-size: 0.64rem;
+  }
+
+  .action-bar {
+    width: clamp(184px, 25vw, 236px);
+    gap: 6px;
+    padding: 7px;
+    border-radius: 18px;
+    background:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.11), rgba(255, 255, 255, 0.02)),
+      linear-gradient(135deg, rgba(255, 212, 90, 0.1), rgba(40, 213, 200, 0.08)),
+      rgba(3, 10, 16, 0.82);
+    box-shadow:
+      0 18px 38px rgba(0, 0, 0, 0.46),
+      inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  }
+
+  .action-bar::before {
+    content: "";
+    position: absolute;
+    inset: 5px;
+    border: 1px solid rgba(40, 213, 200, 0.14);
+    border-radius: 14px;
+    pointer-events: none;
+  }
+
+  .action-summary {
+    min-height: 25px;
+  }
+
+  .action-summary strong {
+    font-size: 0.7rem;
+    color: #fff0c4;
+  }
+
+  .amount-control {
+    gap: 4px;
+    padding: 6px;
+    border-radius: 12px;
+  }
+
+  .amount-control label {
+    font-size: 0.5rem;
+  }
+
+  #bet-value {
+    font-size: 0.82rem;
+  }
+
+  .amount-stepper {
+    grid-template-columns: 30px minmax(0, 1fr) 30px;
+  }
+
+  .amount-stepper button {
+    width: 30px;
+    min-width: 30px;
+    min-height: 30px;
+    border-radius: 10px;
+  }
+
+  .actions {
+    gap: 6px;
+  }
+
+  .actions button {
+    min-height: 39px;
+    border-radius: 13px;
+    font-size: 0.74rem;
+    font-weight: 950;
+  }
+
+  #bet-raise-btn {
+    min-height: 44px;
+    font-size: 0.78rem;
+  }
+}
+
+@media (max-width: 760px) and (orientation: landscape) {
+  .table-stage {
+    --table-side-inset: clamp(96px, 17vw, 128px);
+  }
+
+  .action-bar {
+    width: clamp(174px, 28vw, 210px);
+  }
+}


### PR DESCRIPTION
## Summary
- Add a CSS-only premium visual layer for the River Rat Poker mobile landscape UI
- Restyle the bayou/casino backdrop, compact header, action dock, buttons, bet control, player tray, and opponent HUD plaques
- Preserve existing card, chip, table, and dealer asset references and leave poker gameplay logic untouched

## Testing
- Verified branch diff only changes `index.html` and adds `premium-ui.css` via GitHub compare
- Not run locally: the local shell in this Codex thread could not spawn commands or access the checkout files
